### PR TITLE
Add documented audio port variables to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,15 @@ AGORA_HOST_PORT=8080
 # into ./media (see docker-compose.yml `volumes:`) and set this to /media.
 AGORA_MEDIA_BASE_URL=https://media.agoracosmica.org
 
+# Host port for Kokoro (English TTS).
+AGORA_TTS_KOKORO_PORT=8880
+
+# Host port for Whisper (transcription). Change it if 8000 is already taken.
+AGORA_STT_PORT=8000
+
+# Host port for Qwen3-TTS (German, nvidia profile).
+AGORA_TTS_QWEN_PORT=8887
+
 # Live audio backend (TTS/STT). The self-host v1 image does NOT include a
 # live audio server. Leaving this empty disables live voice cleanly: the
 # microphone input and live-TTS controls hide, and pre-recorded audio


### PR DESCRIPTION
Summary:
- Add the three documented audio port variables to .env.example
- Keep defaults and comments aligned with docs/SELF-HOSTING.md

Verification:
- git diff --check

Closes #6