### PR TITLE
feat: add ariaLabel prop to ToggleSwitch for a11y (fixes #8)

### DIFF
--- a/client/src/components/ToggleSwitch.tsx
+++ b/client/src/components/ToggleSwitch.tsx
@@ -8,6 +8,7 @@ interface ToggleSwitchProps {
   id?: string;
   className?: string;
   size?: 'small' | 'medium' | 'large';
+  ariaLabel?: string;
 }
 
 /**
@@ -20,6 +21,7 @@ interface ToggleSwitchProps {
  * @param {string} props.id Optional ID for the toggle
  * @param {string} props.className Optional additional CSS classes
  * @param {string} props.size Size of toggle - small, medium (default), or large
+ * @param {string} props.ariaLabel Optional aria-label
  */
 const ToggleSwitch: FC<ToggleSwitchProps> = ({ 
   checked = false, 
@@ -27,7 +29,8 @@ const ToggleSwitch: FC<ToggleSwitchProps> = ({
   disabled = false, 
   id, 
   className = '',
-  size = 'medium'
+  size = 'medium',
+  ariaLabel = ''
 }) => {
   // Size mapping for the icons
   const sizeMap: Record<string, number> = {
@@ -63,6 +66,7 @@ const ToggleSwitch: FC<ToggleSwitchProps> = ({
       disabled={disabled}
       role="switch"
       aria-checked={checked}
+      aria-label={ariaLabel}
       style={{
         background: 'transparent',
         border: 'none',

--- a/client/src/components/settings/panels/SpeechPanel.tsx
+++ b/client/src/components/settings/panels/SpeechPanel.tsx
@@ -75,6 +75,7 @@ const SpeechPanel: FC<SpeechPanelProps> = ({
             checked={config.sttEnabled !== false}
             onChange={(value) => onChange('sttEnabled', value)}
             size="medium"
+            ariaLabel={tString('settings.speech.enabled')}
           />
         </div>
       </div>

--- a/client/src/components/settings/panels/VoicePanel.tsx
+++ b/client/src/components/settings/panels/VoicePanel.tsx
@@ -393,6 +393,7 @@ const VoicePanel: FC<VoicePanelProps> = ({
             checked={config.ttsEnabled !== false}
             onChange={(value) => onChange('ttsEnabled', value)}
             size="medium"
+            ariaLabel={tString('settings.voice.enabled')}
           />
         </div>
       </div>


### PR DESCRIPTION
## What does this PR do?

Adds an optional ariaLabel prop to the ToggleSwitch component and uses it in VoicePanel and SpeechPanel with existing translation keys (settings.voice.enabled and settings.speech.enabled). This gives the toggle switches an accessible name for screen readers.

Closes #8

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Content update (figures, translations, factchecks)
- [ ] Documentation
- [ ] Performance improvement
- [x] Accessibility improvement
- [ ] Refactoring (no functional change)
- [ ] CI / build / tooling

## Checklist

- [ ] `pnpm build` completes without errors
- [ ] `pnpm test` passes
- [ ] `npx tsc --noEmit` reports 0 errors
- [ ] Tested on mobile viewport (if UI change)
- [ ] Both EN and DE translations updated (if UI text changed)
- [ ] No hex colors used (CSS variables only)
- [ ] Touch targets are 44px minimum (if interactive elements added)



