### PR TITLE
feat: add htmlFor/id pairs for input fields in LocalModePanel (#5)

### DIFF
--- a/client/src/components/settings/panels/LocalModePanel.tsx
+++ b/client/src/components/settings/panels/LocalModePanel.tsx
@@ -361,10 +361,11 @@ const LocalModePanel: FC<LocalModePanelProps> = ({ SettingCard, CATEGORY_ICONS }
 
         {llmEnabled && (
           <>
-            <label style={labelStyle}>
+            <label style={labelStyle} htmlFor='local-llm-endpoint'>
               {tNode('settings.aiModelKey.custom.endpointLabel')}
             </label>
             <input
+              id='local-llm-endpoint'
               type="text"
               value={endpointURL}
               onChange={(e) => setEndpointURL(e.target.value)}
@@ -372,10 +373,11 @@ const LocalModePanel: FC<LocalModePanelProps> = ({ SettingCard, CATEGORY_ICONS }
               style={inputStyle}
             />
 
-            <label style={labelStyle}>
+            <label style={labelStyle} htmlFor='local-llm-model'>
               {tNode('settings.aiModelKey.custom.modelLabel')}
             </label>
             <input
+              id='local-llm-model'
               type="text"
               value={modelName}
               onChange={(e) => setModelName(e.target.value)}
@@ -422,10 +424,11 @@ const LocalModePanel: FC<LocalModePanelProps> = ({ SettingCard, CATEGORY_ICONS }
 
         {ttsEnabled && (
           <>
-            <label style={labelStyle}>
+            <label style={labelStyle} htmlFor='local-tts-kokoro'>
               {tString('settings.localMode.urlOverrides.kokoroLabel', 'English endpoint (Kokoro)')}
             </label>
             <input
+              id='local-tts-kokoro'
               type="text"
               value={kokoroURL}
               onChange={(e) => setKokoroURL(e.target.value)}
@@ -433,10 +436,11 @@ const LocalModePanel: FC<LocalModePanelProps> = ({ SettingCard, CATEGORY_ICONS }
               style={inputStyle}
             />
 
-            <label style={labelStyle}>
+            <label style={labelStyle} htmlFor='local-tts-qwen'>
               {tString('settings.localMode.urlOverrides.qwenLabel', 'German endpoint (Qwen3-TTS)')}
             </label>
             <input
+              id='local-tts-qwen'
               type="text"
               value={qwenURL}
               onChange={(e) => setQwenURL(e.target.value)}
@@ -474,10 +478,11 @@ const LocalModePanel: FC<LocalModePanelProps> = ({ SettingCard, CATEGORY_ICONS }
 
         {sttEnabled && (
           <>
-            <label style={labelStyle}>
+            <label style={labelStyle} htmlFor='local-stt-whisper'>
               {tString('settings.localMode.urlOverrides.whisperLabel', 'Whisper endpoint')}
             </label>
             <input
+              id='local-stt-whisper'
               type="text"
               value={sttURL}
               onChange={(e) => setSttURL(e.target.value)}


### PR DESCRIPTION
## What does this PR do?

Adds missing `htmlFor` / `id` pairs to the five input fields in `LocalModePanel` (LLM endpoint, LLM model, Kokoro TTS, Qwen TTS, Whisper STT). This improves accessibility by allowing screen readers to announce the correct label and by making the label clickable to focus the input.

Closes #5

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Content update (figures, translations, factchecks)
- [ ] Documentation
- [ ] Performance improvement
- [x] Accessibility improvement
- [ ] Refactoring (no functional change)
- [ ] CI / build / tooling

## Checklist

- [ ] `pnpm build` completes without errors
- [ ] `pnpm test` passes
- [ ] `npx tsc --noEmit` reports 0 errors
- [ ] Tested on mobile viewport (if UI change)
- [ ] Both EN and DE translations updated (if UI text changed)
- [ ] No hex colors used (CSS variables only)
- [ ] Touch targets are 44px minimum (if interactive elements added)

