### PR TITLE
fix: handle pre-aborted fetch signals

### DIFF
--- a/client/src/__tests__/utils/fetchWithTimeout.test.ts
+++ b/client/src/__tests__/utils/fetchWithTimeout.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchWithTimeout } from '@/utils/fetchWithTimeout';
+
+describe('fetchWithTimeout', () => {
+  it('handles a signal already aborted before fetch', async () => {
+    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      if (!init?.signal?.aborted) {
+        return Promise.reject(new Error('fetch started with a live signal'));
+      }
+
+      return Promise.reject(new DOMException('The operation was aborted.', 'AbortError'));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(fetchWithTimeout('/test', { signal: controller.signal })).rejects.toMatchObject({
+      name: 'AbortError',
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});

--- a/client/src/utils/fetchWithTimeout.ts
+++ b/client/src/utils/fetchWithTimeout.ts
@@ -22,6 +22,7 @@ export async function fetchWithTimeout(
   // If caller provided a signal, abort our controller when theirs fires
   const onExternalAbort = () => controller.abort();
   externalSignal?.addEventListener('abort', onExternalAbort, { once: true });
+  if (externalSignal?.aborted) onExternalAbort();
 
   try {
     const response = await fetch(url, {


### PR DESCRIPTION
## Summary

Handle a caller signal that is already aborted when fetchWithTimeout starts, with a focused regression for the pre-aborted path.

## Change

- `client/src/__tests__/utils/fetchWithTimeout.test.ts`
- `client/src/utils/fetchWithTimeout.ts`

### Checks
- `corepack pnpm@8.15.5 --dir client test:unit -- src/__tests__/utils/fetchWithTimeout.test.ts` — passed in a network-isolated container.
- `corepack pnpm@8.15.5 --dir client exec tsc --noEmit` — passed in a network-isolated container.
- `corepack pnpm@8.15.5 --dir client build:client` — passed in a network-isolated container.

Fixes #17

---
AI assistance was used; I reviewed and own this change.

<!-- northset-receipt:M-106:start -->
### Verification

the repository's declared test command exited 0 on this exact head (`5fbd2c8`) in a network-off container, before this PR was opened.
Commands, environment, and hashes: [receipt M-106](https://northset-oss.github.io/verification-pilot/receipts/M-106/) — checkable in ~30 seconds without trusting us.
This record covers Northset's own contribution; it is not maintainer verification.
Maintainers: request a separate private run for any PR in your queue — open a run request: https://github.com/northset-oss/verification-pilot/issues/new?template=request-a-run.yml or email oss@northset.ai.
For repositories already onboarded with Northset, adding `northset-verify` to a PR requests a run on that PR.
<!-- northset-receipt:M-106:end -->
